### PR TITLE
refactor: use proper grammar and punctuation

### DIFF
--- a/router/routes/NotFound.go
+++ b/router/routes/NotFound.go
@@ -12,13 +12,13 @@ func NotFound(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"ROUTE_NOT_FOUND"},
-			"message": "This route could not be found. Please provide a valid route and try again",
+			"message": "This route could not be found. Please provide a valid route and try again.",
 		})
 	}
 
 	return ctx.Status(fiber.StatusNotFound).JSON(fiber.Map{
 		"status":  "ERROR",
 		"errors":  structs.Errors{"ROUTE_NOT_FOUND"},
-		"message": "This route could not be found. Please provide a valid route and try again. (Maybe you mean /v2" + ctx.Path() + "?)",
+		"message": "This route could not be found. Please provide a valid route and try again. (Maybe you meant /v2" + ctx.Path() + "?)",
 	})
 }

--- a/router/routes/admin/AddInvite.go
+++ b/router/routes/admin/AddInvite.go
@@ -14,7 +14,7 @@ func AddInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing a API key.",
+			"message": "You are missing an API key.",
 		})
 	}
 
@@ -22,17 +22,17 @@ func AddInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "Valid invites start with SHIB. Please make your invite start with SHIB and then try again.",
+			"message": "Please ensure the invite starts with SHIB before trying again.",
 		})
 	}
 
 	col := structs.DB.Collection("invites")
 
-	if _, err := col.InsertOne(context.TODO(), bson.M{"invite": ctx.Query("invite"), "active": true, "madeby": "Admin (This user was invited by a administrator)", "usedBy": bson.M{"email": "", "date": "Never"}}); err != nil {
+	if _, err := col.InsertOne(context.TODO(), bson.M{"invite": ctx.Query("invite"), "active": true, "madeby": "Admin (This user was invited by an administrator)", "usedBy": bson.M{"email": "", "date": "Never"}}); err != nil {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An error occurred adding your invite.",
+			"message": "An error occurred while adding the invite.",
 			"error":   err.Error(),
 		})
 	}
@@ -40,7 +40,7 @@ func AddInvite(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
 		"status":  "OK",
 		"errors":  structs.Errors{},
-		"message": "Your invite has been successfully added to the database.",
+		"message": "The invite has been successfully added to the database.",
 		"invite": fiber.Map{
 			"invite": ctx.Query("invite"),
 			"active": true,

--- a/router/routes/admin/BanUser.go
+++ b/router/routes/admin/BanUser.go
@@ -14,7 +14,7 @@ func BanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing a API key.",
+			"message": "You are missing an API key.",
 		})
 	}
 
@@ -24,7 +24,7 @@ func BanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNKNOWN_ERROR"},
-			"message": "An unknown error occurred",
+			"message": "An unknown error occurred.",
 		})
 	}
 
@@ -42,7 +42,7 @@ func BanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNKNOWN_ERROR"},
-			"message": "There was an error updating the blacklisted status for the user",
+			"message": "There was an error updating the blacklisted status for the user.",
 			"error":   err.Error(),
 		})
 	}

--- a/router/routes/admin/GetInvite.go
+++ b/router/routes/admin/GetInvite.go
@@ -15,7 +15,7 @@ func GetInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing a API key.",
+			"message": "You are missing an API key.",
 		})
 	}
 
@@ -23,7 +23,7 @@ func GetInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "A valid invite starts with SHIB. Please lookup a valid invite and then try again",
+			"message": "Please ensure the invite starts with SHIB and is valid before trying again",
 		})
 	}
 
@@ -35,7 +35,7 @@ func GetInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An error occurred looking up your invite.",
+			"message": "An error occurred looking up the invite.",
 			"error":   err.Error(),
 		})
 	}

--- a/router/routes/admin/RemoveInvite.go
+++ b/router/routes/admin/RemoveInvite.go
@@ -14,7 +14,7 @@ func RemoveInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing a API key.",
+			"message": "You are missing an API key.",
 		})
 	}
 
@@ -22,7 +22,7 @@ func RemoveInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "Valid invites start with SHIB. Please make your invite start with SHIB and then try again.",
+			"message": "Please ensure the invite starts with SHIB before trying again.",
 		})
 	}
 
@@ -34,7 +34,7 @@ func RemoveInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"INVALID_INVITE"},
-			"message": "The invite you provided was invalid.",
+			"message": "The invite provided was invalid.",
 		})
 	}
 
@@ -42,7 +42,7 @@ func RemoveInvite(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An error occurred removing your invite.",
+			"message": "An error occurred removing the invite.",
 			"error":   err.Error(),
 		})
 	}
@@ -50,6 +50,6 @@ func RemoveInvite(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
 		"status":  "OK",
 		"errors":  structs.Errors{},
-		"message": "Your invite has been successfully removed",
+		"message": "The invite has been successfully removed.",
 	})
 }

--- a/router/routes/admin/UnbanUser.go
+++ b/router/routes/admin/UnbanUser.go
@@ -15,7 +15,7 @@ func UnbanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing a API key.",
+			"message": "You are missing an API key.",
 		})
 	}
 
@@ -25,7 +25,7 @@ func UnbanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":             "ERROR",
 			"errors":             structs.Errors{"UNKNOWN_ERROR"},
-			"message":            "An unknown error occurred",
+			"message":            "An unknown error occurred.",
 			"statusCodeReturned": status,
 			"body":               util.Base64Decode(body),
 		})
@@ -45,7 +45,7 @@ func UnbanUser(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNKNOWN_ERROR"},
-			"message": "There was an error updating the blacklisted status for the user",
+			"message": "There was an error updating the blacklisted status for the user.",
 			"error":   err.Error(),
 		})
 	}

--- a/router/routes/auth/Register.go
+++ b/router/routes/auth/Register.go
@@ -30,7 +30,7 @@ func complete(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"INVALID_INVITE"},
-			"message": "The invite you provided was invalid. Please try again later.",
+			"message": "The invite provided was invalid. Please try again later.",
 		})
 	}
 
@@ -38,7 +38,7 @@ func complete(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An unexpected error has occurred",
+			"message": "An unexpected error has occurred.",
 			"error":   err.Error(),
 		})
 	}
@@ -49,7 +49,7 @@ func complete(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An unexpected error has occurred",
+			"message": "An unexpected error has occurred.",
 		})
 	}
 
@@ -59,7 +59,7 @@ func complete(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"UNEXPECTED_ERROR"},
-			"message": "An unexpected error has occurred",
+			"message": "An unexpected error has occurred.",
 		})
 	}
 
@@ -89,7 +89,7 @@ func complete(ctx *fiber.Ctx) error {
 	return ctx.JSON(fiber.Map{
 		"status":  "OK",
 		"errors":  structs.Errors{},
-		"message": "Registered account successfully",
+		"message": "Registered account successfully.",
 		"user": fiber.Map{
 			"email":    Email,
 			"invite":   Invite,
@@ -108,7 +108,7 @@ func Register(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"status":  "ERROR",
 			"errors":  structs.Errors{"VALIDATION_ERROR"},
-			"message": "You are missing an @ in your email.",
+			"message": "The email provided is missing an \"@\".",
 		})
 	}
 
@@ -121,6 +121,6 @@ func Register(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 		"status":  "ERROR",
 		"errors":  structs.Errors{"VALIDATION_ERROR"},
-		"message": "You are missing a valid domain in your email.",
+		"message": "The email provided is missing a valid domain.",
 	})
 }


### PR DESCRIPTION
This PR fixes the grammar used in the API response messages. It also standardizes punctuations such as having a period at the end of response messages.